### PR TITLE
Change case from "PowerTools" to "powertools"

### DIFF
--- a/base/centos8/Dockerfile
+++ b/base/centos8/Dockerfile
@@ -22,7 +22,7 @@ RUN yum -y update && \
                    texlive-times texlive-makeindex texlive-helvetic texlive-courier texlive-gsftopk texlive-dvips texlive-mfware texlive-dvisvgm && \
     pip3 install rst2pdf sphinx sphinxcontrib-programoutput && \
     pip3 install git+https://github.com/esmci/sphinx_rtd_theme.git@version-dropdown-with-fixes && \
-    dnf --enablerepo=PowerTools install -y blas-devel lapack-devel && \
+    dnf --enablerepo=powertools install -y blas-devel lapack-devel && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     echo '/usr/local/lib' > /etc/ld.so.conf.d/local.conf && \
     ldconfig && \


### PR DESCRIPTION
I had a docker build fail on base/centos8 with error message:
`Error: Unknown repo: 'PowerTools'`

This article suggested changing the case, which seems to have worked:
https://serverfault.com/questions/997896/how-to-enable-powertools-repository-in-centos-8

This PR changes the case.