### PR TITLE
Add support for Markdown in Sphinx-based documentation

### DIFF
--- a/base/centos8/Dockerfile
+++ b/base/centos8/Dockerfile
@@ -72,14 +72,10 @@ RUN  cd /tmp/sources && \
      ldconfig
 
 RUN  cd /tmp/sources && \
-     wget -q https://parallel-netcdf.github.io/Release/pnetcdf-1.12.1.tar.gz && \
-     tar zxf pnetcdf-1.12.1.tar.gz && \
-     cd pnetcdf-1.12.1 && \
-     FFLAGS="-w -fallow-argument-mismatch" \
-     FCLAGS="-w -fallow-argument-mismatch" \
+     wget -q https://parallel-netcdf.github.io/Release/pnetcdf-1.12.2.tar.gz && \
+     tar zxf pnetcdf-1.12.2.tar.gz && \
+     cd pnetcdf-1.12.2 && \
      ./configure --prefix=/usr/local && \
-     FFLAGS="-w -fallow-argument-mismatch" \
-     FCLAGS="-w -fallow-argument-mismatch" \
      make -j 2 install && \
      ldconfig && \
      rm -rf /tmp/sources

--- a/base/centos8/Dockerfile
+++ b/base/centos8/Dockerfile
@@ -75,7 +75,11 @@ RUN  cd /tmp/sources && \
      wget -q https://parallel-netcdf.github.io/Release/pnetcdf-1.12.1.tar.gz && \
      tar zxf pnetcdf-1.12.1.tar.gz && \
      cd pnetcdf-1.12.1 && \
+     FFLAGS="-w -fallow-argument-mismatch" \
+     FCLAGS="-w -fallow-argument-mismatch" \
      ./configure --prefix=/usr/local && \
+     FFLAGS="-w -fallow-argument-mismatch" \
+     FCLAGS="-w -fallow-argument-mismatch" \
      make -j 2 install && \
      ldconfig && \
      rm -rf /tmp/sources

--- a/base/centos8/Dockerfile
+++ b/base/centos8/Dockerfile
@@ -5,7 +5,7 @@
 ################################################################################################################
 
 # Use latest CentOS8 clone hosted by Oracle:
-FROM oraclelinux:8
+FROM oraclelinux:9
 
 # First, we upate the default packages and install some other necessary ones - while this may give
 # some people updated versions of packages vs. others, these differences should not be numerically

--- a/base/centos8/Dockerfile
+++ b/base/centos8/Dockerfile
@@ -22,7 +22,7 @@ RUN yum -y update && \
                    texlive-times texlive-makeindex texlive-helvetic texlive-courier texlive-gsftopk texlive-dvips texlive-mfware texlive-dvisvgm && \
     pip3 install rst2pdf sphinx sphinxcontrib-programoutput && \
     pip3 install git+https://github.com/esmci/sphinx_rtd_theme.git@version-dropdown-with-fixes && \
-    dnf --enablerepo=powertools install -y blas-devel lapack-devel && \
+    dnf --enablerepo=ol9_codeready_builder install -y blas-devel lapack-devel && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     echo '/usr/local/lib' > /etc/ld.so.conf.d/local.conf && \
     ldconfig && \

--- a/base/centos8/Dockerfile
+++ b/base/centos8/Dockerfile
@@ -14,7 +14,7 @@ FROM oraclelinux:9
 RUN yum -y update && \
     yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     yum -y install vim emacs-nox git subversion which sudo csh make m4 cmake wget file byacc curl-devel zlib-devel && \
-    yum -y install perl-XML-LibXML gcc-gfortran gcc-c++ dnf-plugins-core python3 perl-core && \
+    yum -y install perl-XML-LibXML gcc-gfortran gcc-c++ dnf-plugins-core python3 pip perl-core && \
     yum -y install ftp xmlstarlet diffutils  && \
     yum -y install git-lfs latexmk texlive-amscls texlive-anyfontsize texlive-cmap texlive-fancyhdr texlive-fncychap \
                    texlive-dvisvgm texlive-metafont texlive-ec texlive-titlesec texlive-babel-english texlive-tabulary \ 

--- a/base/centos8/Dockerfile
+++ b/base/centos8/Dockerfile
@@ -56,16 +56,16 @@ RUN  mkdir /tmp/sources && \
      make -j 2 install
 
 RUN  cd /tmp/sources && \
-     wget -q ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-4.7.4.tar.gz  && \
-     tar zxf netcdf-c-4.7.4.tar.gz && \
+     wget -q https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.7.4.tar.gz && \
+     tar zxf v4.7.4.tar.gz && \
      cd netcdf-c-4.7.4 && \
      ./configure --prefix=/usr/local && \
      make -j 2 install && \
      ldconfig
 
 RUN  cd /tmp/sources && \
-     wget -q ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-fortran-4.5.3.tar.gz && \
-     tar zxf netcdf-fortran-4.5.3.tar.gz && \
+     wget -q https://github.com/Unidata/netcdf-fortran/archive/refs/tags/v4.5.3.tar.gz && \
+     tar zxf v4.5.3.tar.gz && \
      cd netcdf-fortran-4.5.3 && \
      ./configure --prefix=/usr/local && \
      make -j 2 install && \

--- a/base/centos8/Dockerfile
+++ b/base/centos8/Dockerfile
@@ -53,22 +53,25 @@ RUN  mkdir /tmp/sources && \
      tar zxf hdf5-1.12.0.tar.gz && \
      cd hdf5-1.12.0 && \
      ./configure --prefix=/usr/local && \
-     make -j 2 install && \
-     cd /tmp/sources && \
+     make -j 2 install
+
+RUN  cd /tmp/sources && \
      wget -q ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-4.7.4.tar.gz  && \
      tar zxf netcdf-c-4.7.4.tar.gz && \
      cd netcdf-c-4.7.4 && \
      ./configure --prefix=/usr/local && \
      make -j 2 install && \
-     ldconfig && \
-     cd /tmp/sources && \
+     ldconfig
+
+RUN  cd /tmp/sources && \
      wget -q ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-fortran-4.5.3.tar.gz && \
      tar zxf netcdf-fortran-4.5.3.tar.gz && \
      cd netcdf-fortran-4.5.3 && \
      ./configure --prefix=/usr/local && \
      make -j 2 install && \
-     ldconfig && \
-     cd /tmp/sources && \
+     ldconfig
+
+RUN  cd /tmp/sources && \
      wget -q https://parallel-netcdf.github.io/Release/pnetcdf-1.12.1.tar.gz && \
      tar zxf pnetcdf-1.12.1.tar.gz && \
      cd pnetcdf-1.12.1 && \

--- a/base/centos8/Dockerfile
+++ b/base/centos8/Dockerfile
@@ -38,6 +38,7 @@ RUN mkdir /tmp/sources && \
     wget -q http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz && \
     tar zxf mpich-3.3.2.tar.gz && \
     cd mpich-3.3.2 && \
+    FFLAGS="-w -fallow-argument-mismatch -O2" \
     ./configure --prefix=/usr/local && \
     make -j 2 install && \
     rm -rf /tmp/sources 

--- a/base/centos8/Dockerfile
+++ b/base/centos8/Dockerfile
@@ -4,8 +4,8 @@
 # A base CentOS8 install + MPI, HDF5, NetCDF and PNetCDF, as well as other core packages for escomp containers #
 ################################################################################################################
 
-# Use latest CentOS8:
-FROM centos:8
+# Use latest CentOS8 clone hosted by Oracle:
+FROM oraclelinux:8
 
 # First, we upate the default packages and install some other necessary ones - while this may give
 # some people updated versions of packages vs. others, these differences should not be numerically

--- a/base/oraclelinux9/Dockerfile
+++ b/base/oraclelinux9/Dockerfile
@@ -1,10 +1,9 @@
 ################################################################################################################
-# escomp/base-centos8 Dockerfile                                                                                    #
+# escomp/base-oraclelinux9e                                                                                    #
 #--------------------------------------------------------------------------------------------------------------#
-# A base CentOS8 install + MPI, HDF5, NetCDF and PNetCDF, as well as other core packages for escomp containers #
+# A base OracleLinux9 install + MPI, HDF5, NetCDF and PNetCDF, plus other core packages for escomp containers  #
 ################################################################################################################
 
-# Use latest CentOS8 clone hosted by Oracle:
 FROM oraclelinux:9
 
 # First, we upate the default packages and install some other necessary ones - while this may give

--- a/base/oraclelinux9/Dockerfile
+++ b/base/oraclelinux9/Dockerfile
@@ -21,6 +21,7 @@ RUN yum -y update && \
                    texlive-times texlive-makeindex texlive-helvetic texlive-courier texlive-gsftopk texlive-dvips texlive-mfware texlive-dvisvgm && \
     pip3 install rst2pdf sphinx sphinxcontrib-programoutput && \
     pip3 install git+https://github.com/esmci/sphinx_rtd_theme.git@version-dropdown-with-fixes && \
+    pip3 install sphinx_mdinclude && \
     dnf --enablerepo=ol9_codeready_builder install -y blas-devel lapack-devel && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     echo '/usr/local/lib' > /etc/ld.so.conf.d/local.conf && \


### PR DESCRIPTION
This PR adds `sphinx_mdinclude` to the base container, which allows Markdown files to be built in Sphinx-based documentation alongside ReStructuredText files.

(Note that this is based at the head of the branch in #15, so I'm marking it as draft until that's merged.)